### PR TITLE
Update example to match v3.x features

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ configuration or /etc/hosts tuning.
 To reach the container from another device on your local network, use the
 following docker label :
 
-    - "traefik.http.routers.app1.rule=HostRegexp(`app1..*.traefik.me`)"
+    - "traefik.http.routers.app1.rule=HostRegexp(`app1\..*\.traefik\.me`)"
 
 Say your LAN IP address is 10.0.0.1, visiting http://app1.10.0.0.1.traefik.me
 from any device on your local network will reach your app1 docker container.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ version: '3'
 services:
   traefik:
     restart: unless-stopped
-    image: traefik:v2.0.2
+    image: traefik:v3.3
     command: --providers.docker=true
     ports:
       - "80:80"
@@ -80,7 +80,7 @@ configuration or /etc/hosts tuning.
 To reach the container from another device on your local network, use the
 following docker label :
 
-    - "traefik.http.routers.app1.rule=HostRegexp(`app1.{ip:.*}.traefik.me`)"
+    - "traefik.http.routers.app1.rule=HostRegexp(`app1..*.traefik.me`)"
 
 Say your LAN IP address is 10.0.0.1, visiting http://app1.10.0.0.1.traefik.me
 from any device on your local network will reach your app1 docker container.


### PR DESCRIPTION
Traefik changed All `*Regexp` to match [golang regex syntax](https://pkg.go.dev/regexp/syntax).

Source:
[redirectregex worked in v2 but not in v3 beta](https://community.traefik.io/t/redirectregex-worked-in-v2-but-not-in-v3-beta/21368)
